### PR TITLE
Add sample Cloud Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Codex IA
+
 Ce dépôt servira à générer des pages pour Marketing Cloud.
+
+## Cloud Pages
+
+The `cloud_pages/` directory contains example templates for Salesforce Marketing Cloud.
+To deploy a page:
+
+1. Open **Content Builder > CloudPages** in Marketing Cloud.
+2. Create a new Landing Page and select **HTML**.
+3. Copy the content of the desired template (`cloud_pages/home.html` or `cloud_pages/contact.html`).
+4. Paste it into the editor, then save and publish the page.
+
+These samples demonstrate simple AMPscript and SSJS usage.

--- a/cloud_pages/contact.html
+++ b/cloud_pages/contact.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Contact</title>
+    <script runat="server">
+        Platform.Load("Core","1");
+        var name = Request.GetQueryStringParameter("name");
+        var email = Request.GetQueryStringParameter("email");
+        if (name && email) {
+            Write("<p>Thanks, " + name + ". We'll contact you at " + email + ".</p>");
+        } else {
+            Write("<p>Please provide your name and email.</p>");
+        }
+    </script>
+</head>
+<body>
+    <h1>Contact Us</h1>
+    <form method="GET" action="%%=RequestParameter('PAGEURL')=%%">
+        <label>Name: <input type="text" name="name" /></label><br />
+        <label>Email: <input type="email" name="email" /></label><br />
+        <input type="submit" value="Send" />
+    </form>
+</body>
+</html>

--- a/cloud_pages/home.html
+++ b/cloud_pages/home.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Home Page</title>
+</head>
+<body>
+    <h1>Welcome to the Home Page</h1>
+    %%[
+        /* Example AMPscript variable for personalization */
+        SET @firstname = [FirstName]
+    ]%%
+    <p>Hello %%=v(@firstname)=%%!</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Cloud Pages templates for Marketing Cloud
- show simple AMPscript in `home.html`
- demonstrate SSJS handling in `contact.html`
- document how to deploy these pages in Marketing Cloud

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b3ceeec148321804168e558400f98